### PR TITLE
fixed command loading on windows

### DIFF
--- a/src/commands/init.mjs
+++ b/src/commands/init.mjs
@@ -20,7 +20,7 @@ export const InitCommands = async (client) => {
         const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
         for (const file of commandFiles) {
             const filePath = path.join(commandsPath, file);
-            const command = await import(filePath);
+            const command = await import("file://"+filePath);
 
             if ('data' in command && 'execute' in command) {
                 Logger.log('info', `Registering command ${command.data.name}`);


### PR DESCRIPTION
Due to a different implementation on nodejs's side for linux and windows for file paths the bot wouldn't start on windows
as it was unable to find the file.

with this PR the load function will add a "file://" prefix what fixes this issue.

previous error:
```
[2024-08-26T15:56:21.788] [INFO] default - Registering module: LevelingModule
[2024-08-26T15:56:21.790] [INFO] default - Initializing commands
node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at new NodeError (node:internal/errors:405:5)
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:131:11)
    at defaultLoad (node:internal/modules/esm/load:82:3)
    at nextLoad (node:internal/modules/esm/loader:163:28)
    at ESMLoader.load (node:internal/modules/esm/loader:603:26)
    at ESMLoader.moduleProvider (node:internal/modules/esm/loader:457:22)
    at new ModuleJob (node:internal/modules/esm/module_job:64:26)
    at #createModuleJob (node:internal/modules/esm/loader:480:17)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:434:34) {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}
```
