### PR TITLE
Add points column and migration script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "dev": "nodemon ./src/bot.js",
     "deploycommands": "node ./src/tools/deploy-commands.js",
     "createdb": "node ./src/tools/create-db.js",
+    "migratedb": "node ./src/tools/migrate-db.js",
     "scrape-levels": "node ./src/tools/scrape-user-roles.js",
-    "import-levels":"node ./src/tools/import-levels.js",
+    "import-levels": "node ./src/tools/import-levels.js",
     "lint": "eslint ."
   },
   "keywords": [],

--- a/src/core/database.mjs
+++ b/src/core/database.mjs
@@ -35,6 +35,7 @@ export const InitDatabase = async () => {
                 primaryKey: true,
             },
             xp: DataTypes.BIGINT,
+            points: DataTypes.BIGINT
         },
         { sequelize: SequelizeDb, modelName: 'DiscordUserXp' },
     );
@@ -49,4 +50,18 @@ export const CreateTables = async (wipe = false) => {
     DatabaseLogger.log('info', 'Creating tables...');
     await SequelizeDb.sync({ force: wipe });
     DatabaseLogger.log('info', 'Done creating tables...');
+}
+
+/**
+ * Migrate the tables in the database
+ * 
+ * This will run SQL commands to modify the tables since the original two
+ * column DiscordUserXp table
+ */
+export const MigrateTables = async () => {
+    DatabaseLogger.log('info', 'Migrating tables')
+    // Add points column to DiscordUserXps
+    const [results, metadata] = await SequelizeDb.query(
+        'alter table "DiscordUserXps" add column if not exists points bigint default 0;');
+    DatabaseLogger.log('info', 'Finished migrating schema')
 }

--- a/src/tools/migrate-db.js
+++ b/src/tools/migrate-db.js
@@ -1,0 +1,11 @@
+import * as dotenv from 'dotenv';
+import { InitConfig } from '../core/config.mjs';
+import { InitLogger } from '../core/logger.mjs';
+import { InitDatabase, MigrateTables } from '../core/database.mjs';
+
+dotenv.config();
+InitConfig();
+InitLogger();
+
+await InitDatabase();
+await MigrateTables();


### PR DESCRIPTION
Here is a database migration script to add the points column that can be run with

```
npm run migratedb
```

Alternatively you can just run this on your bot's docker host:

```
echo 'alter table "DiscordUserXps" add column if not exists points bigint default 0;' | docker compose exec -T sudo-bot-db psql -U admin sudobotdb
```

Tried to keep it simple as I see the project isn't using Sequelize database migrations and you're working on bot v2